### PR TITLE
Fix issue in check for "ip" key

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -61,8 +61,8 @@ def handler(event, context):
         id = message["random_id"]
         message_time = message["datetime"]
         message["@timestamp"] = message_time
-        if not message["ip"]:
-            message.pop["ip"]
+        if "ip" in message and not message["ip"]:
+            message.pop("ip")
         message_date = str(datetime.fromisoformat(message_time).date())
         index = index_prefix + message_date
         action = {"_index": index, "_id": id, "_source": message}


### PR DESCRIPTION
Getting this error when enabled kinesis-to-opensearch in a new environment
```
[ERROR] KeyError: 'ip'
Traceback (most recent call last):
  File "/var/task/lambda_function.py", line 64, in handler
    if not message["ip"]:
```