### PR TITLE
Batch events to splunk + extract splunk config from single aws secret

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -42,11 +42,10 @@ def _process_kinesis_record(record):
     message["@timestamp"] = message_time
     if "ip" in message and not message["ip"]:
         message.pop("ip")
-    message_date = str(datetime.fromisoformat(message_time).date())
-    return message, message_date
+    return message
 
 
-def elasticsearch_handler(event, context):
+def elasticsearch_handler(processed_records, context):
     es_host = os.environ["es_endpoint"]
     elastic_search_secret = os.environ["secret_name"]
     es_index_prefix = os.environ["index_prefix"]
@@ -67,20 +66,21 @@ def elasticsearch_handler(event, context):
     )
 
     actions = []
-    for record in event["Records"]:
-        message, message_date = _process_kinesis_record(record)
-        index = es_index_prefix + message_date
+    for message in processed_records:
+        if message is None:
+            continue
+        index = es_index_prefix + str(datetime.fromisoformat(message["datetime"]).date())
         action = {"_index": index, "_id":  message["random_id"], "_source": message}
         actions.append(action)
 
     success, errors = helpers.bulk(client, actions, max_retries=3, raise_on_error=False)
     if errors:
         logger.error(errors)
-    total = len(event["Records"])
+    total = len(processed_records)
     print(f"Successfully processed {success}/{total} items for opensearch")
 
 
-def _send_to_splunk(events, errors, splunk_hec_url, splunk_hec_token):
+def _send_to_splunk(events, splunk_hec_url, splunk_hec_token):
     try:
         response = requests.post(
             splunk_hec_url,
@@ -91,48 +91,45 @@ def _send_to_splunk(events, errors, splunk_hec_url, splunk_hec_token):
         response.raise_for_status()
         return len(events)
     except Exception as e:
-        errors.append(str(e))
+        logger.error(str(e))
         return 0
 
-def splunk_handler(event, context):
+def splunk_handler(processed_records, context):
     secret = get_secret(os.environ["secret_name"])
     # splunk HEC configuration
     splunk_hec_url = secret["splunk_hec_url"]
     splunk_hec_token = secret["splunk_hec_token"]
     splunk_index = secret["splunk_index"]
     success_count = 0
-    errors = []
     events = []
     max_batch_size = 500
 
-    for record in event["Records"]:
-        message, message_date = _process_kinesis_record(record)
+    for message in processed_records:
         if message is None:
             continue
         # Create splunk payload
         event = {
             "event": message,
             "sourcetype": "json",
-            "index": splunk_index + message_date,
+            "index": splunk_index + str(datetime.fromisoformat(message["datetime"]).date()),
             "time": message["datetime"],
             "_id": message["random_id"],
         }
         events.append(event)
         # if the number of events reaches the max batch size, send them to Splunk
         if len(events) >= max_batch_size:
-            sent = _send_to_splunk(events, errors, splunk_hec_url, splunk_hec_token)
+            sent = _send_to_splunk(events, splunk_hec_url, splunk_hec_token)
             success_count += sent
             events = []
     # Send remaining events
     if events:
-        sent = _send_to_splunk(events, errors, splunk_hec_url, splunk_hec_token)
+        sent = _send_to_splunk(events, splunk_hec_url, splunk_hec_token)
         success_count += sent
 
-    if errors:
-        logger.error(errors)
-    total = len(event["Records"])
+    total = len(processed_records)
     print(f"Successfully processed {success_count}/{total} items to Splunk")
 
 def handler(event, context):
-    elasticsearch_handler(event,context)
-    splunk_handler(event,context)
+    processed_records = [_process_kinesis_record(r) for r in event["Records"]]
+    elasticsearch_handler(processed_records,context)
+    splunk_handler(processed_records,context)


### PR DESCRIPTION
Following changes are included:
1. Batching events into chunks before sending to splunk HEC since lambda is configured to process ~10,000 events per record. This should allow splunk to process events at a faster rate. 
2. Since configuring a separate AWS secret for storing splunk config is not possible because of app-interface reconciler limitation, the change uses existing elastic search secret to extract splunk config