### PR TITLE
Modify splunk payload to remove unsupported fields

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -112,8 +112,6 @@ def splunk_handler(processed_records, context):
             "event": message,
             "sourcetype": "json",
             "index": splunk_index,
-            "time": message["datetime"],
-            "_id": message["random_id"],
         }
         events.append(event)
         # if the number of events reaches the max batch size, send them to Splunk


### PR DESCRIPTION
Removes unsupported fields to avoid `400 Bad request` error from Splunk. Both `datetime` and `id` are already part of `message` payload and they are automatically parsed in splunk 