### PR TITLE
Optimize connection reuse and reduce API calls

### DIFF
--- a/test_lambda_function.py
+++ b/test_lambda_function.py
@@ -20,6 +20,17 @@ def mock_env(monkeypatch):
     monkeypatch.setenv("index_prefix", "logs-")
 
 
+@pytest.fixture(autouse=True)
+def reset_global_clients():
+    """Reset global client variables between tests."""
+    import lambda_function
+    lambda_function.opensearch_client = None
+    lambda_function.splunk_session = None
+    yield
+    lambda_function.opensearch_client = None
+    lambda_function.splunk_session = None
+
+
 @pytest.fixture
 def sample_record_with_extended_fields():
     """Sample log record containing extended fields."""
@@ -143,14 +154,31 @@ class TestProcessKinesisRecord:
 class TestHandler:
     """Tests for handler function - verifies ES gets stripped records, Splunk gets full records."""
 
+    @patch("lambda_function.requests.Session")
+    @patch("lambda_function._build_opensearch_client")
+    @patch("lambda_function.get_secret")
     @patch("lambda_function.splunk_handler")
     @patch("lambda_function.elasticsearch_handler")
     def test_es_receives_stripped_records(
         self,
         mock_es_handler,
         mock_splunk_handler,
+        mock_get_secret,
+        mock_build_client,
+        mock_session,
         sample_record_with_extended_fields,
     ):
+        mock_get_secret.return_value = {
+            "master_user_name": "test_user",
+            "master_user_password": "test_pass",
+            "splunk_hec_url": "https://splunk.test",
+            "splunk_hec_token": "test-token",
+            "splunk_index": "test-index",
+            "splunk_disabled": False,
+        }
+        mock_build_client.return_value = MagicMock()
+        mock_session.return_value = MagicMock()
+
         event = {"Records": [create_kinesis_record(sample_record_with_extended_fields)]}
         context = MagicMock()
 
@@ -161,14 +189,31 @@ class TestHandler:
         for field in EXTENDED_FIELDS:
             assert field not in es_records[0]
 
+    @patch("lambda_function.requests.Session")
+    @patch("lambda_function._build_opensearch_client")
+    @patch("lambda_function.get_secret")
     @patch("lambda_function.splunk_handler")
     @patch("lambda_function.elasticsearch_handler")
     def test_splunk_receives_full_records(
         self,
         mock_es_handler,
         mock_splunk_handler,
+        mock_get_secret,
+        mock_build_client,
+        mock_session,
         sample_record_with_extended_fields,
     ):
+        mock_get_secret.return_value = {
+            "master_user_name": "test_user",
+            "master_user_password": "test_pass",
+            "splunk_hec_url": "https://splunk.test",
+            "splunk_hec_token": "test-token",
+            "splunk_index": "test-index",
+            "splunk_disabled": False,
+        }
+        mock_build_client.return_value = MagicMock()
+        mock_session.return_value = MagicMock()
+
         event = {"Records": [create_kinesis_record(sample_record_with_extended_fields)]}
         context = MagicMock()
 
@@ -180,13 +225,30 @@ class TestHandler:
         assert "http_method" in splunk_records[0]
         assert "performer_username" in splunk_records[0]
 
+    @patch("lambda_function.requests.Session")
+    @patch("lambda_function._build_opensearch_client")
+    @patch("lambda_function.get_secret")
     @patch("lambda_function.splunk_handler")
     @patch("lambda_function.elasticsearch_handler")
     def test_handler_processes_multiple_records(
         self,
         mock_es_handler,
         mock_splunk_handler,
+        mock_get_secret,
+        mock_build_client,
+        mock_session,
     ):
+        mock_get_secret.return_value = {
+            "master_user_name": "test_user",
+            "master_user_password": "test_pass",
+            "splunk_hec_url": "https://splunk.test",
+            "splunk_hec_token": "test-token",
+            "splunk_index": "test-index",
+            "splunk_disabled": False,
+        }
+        mock_build_client.return_value = MagicMock()
+        mock_session.return_value = MagicMock()
+
         records = [
             {"datetime": "2026-02-18T10:30:00", "random_id": "1", "request_url": "/a"},
             {"datetime": "2026-02-18T10:31:00", "random_id": "2", "http_method": "GET"},
@@ -211,14 +273,31 @@ class TestHandler:
         assert "http_method" in splunk_records[1]
         assert "user_agent" in splunk_records[2]
 
+    @patch("lambda_function.requests.Session")
+    @patch("lambda_function._build_opensearch_client")
+    @patch("lambda_function.get_secret")
     @patch("lambda_function.splunk_handler")
     @patch("lambda_function.elasticsearch_handler")
     def test_es_and_splunk_both_called(
         self,
         mock_es_handler,
         mock_splunk_handler,
+        mock_get_secret,
+        mock_build_client,
+        mock_session,
         sample_record_minimal,
     ):
+        mock_get_secret.return_value = {
+            "master_user_name": "test_user",
+            "master_user_password": "test_pass",
+            "splunk_hec_url": "https://splunk.test",
+            "splunk_hec_token": "test-token",
+            "splunk_index": "test-index",
+            "splunk_disabled": False,
+        }
+        mock_build_client.return_value = MagicMock()
+        mock_session.return_value = MagicMock()
+
         event = {"Records": [create_kinesis_record(sample_record_minimal)]}
         context = MagicMock()
 


### PR DESCRIPTION
## Summary

This PR optimizes Lambda performance by implementing connection reuse for OpenSearch and Splunk clients, reducing redundant Secrets Manager API calls, and improving OpenSearch indexing throughput with parallel bulk operations.

**Performance improvements:**
- OpenSearch and Splunk HTTP connections are now reused across warm Lambda invocations
- Secrets Manager API calls reduced from 2-3 per invocation to 1
- Eliminated redundant client initialization overhead on warm starts
- OpenSearch indexing now uses parallel bulk operations for better throughput

## Changes

### Connection Reuse
- Added module-level `opensearch_client` and `splunk_session` variables that persist across warm Lambda container invocations
- Clients are initialized once on first invocation and reused on subsequent invocations
- Leverages built-in connection pooling in both OpenSearch Python client (urllib3) and requests.Session

### OpenSearch Parallel Bulk Operations
- Replaced `helpers.bulk()` with `helpers.parallel_bulk()` for concurrent indexing
- Uses 4 worker threads to send data in parallel
- Chunks data into 500-record batches automatically
- Significantly improves throughput for large Kinesis batches (up to 10,000 records)

### Code Refactoring
- Extracted OpenSearch client creation into `_build_opensearch_client()` helper function
- Refactored `elasticsearch_handler()` and `splunk_handler()` to accept clients as parameters (dependency injection)
- Simplified `splunk_handler()` by moving secret retrieval and session initialization to the main handler
- Skip Splunk session initialization when `splunk_disabled` is true

### API Call Optimization
- `get_secret()` now called once per invocation instead of 2-3 times
- Secret values are reused across handler functions
- Reduces Secrets Manager costs and latency

### Test Updates
- Updated all handler tests to mock new dependencies (`get_secret`, `_build_opensearch_client`, `requests.Session`)
- Added fixture to reset global client variables between tests
- All 13 tests passing

## Performance Impact

**Cold start (first invocation):**
- Behavior unchanged
- 1 Secrets Manager API call

**Warm invocation (container reuse):**
- Before: New client/session created each time, 2-3 Secrets Manager calls, sequential bulk operations
- After: Existing clients reused, 1 Secrets Manager API call, parallel bulk operations
- Expected latency reduction: ~100-200ms per warm invocation
- Expected throughput improvement for large batches: 2-4x faster OpenSearch indexing

## Test plan
- [ ] Deploy to dev environment
- [ ] Verify logs are successfully sent to OpenSearch
- [ ] Verify logs are successfully sent to Splunk (when enabled)
- [ ] Verify splunk_disabled flag is respected
- [ ] Monitor CloudWatch metrics for latency improvements
- [ ] Verify no errors in CloudWatch Logs
- [ ] Test with large Kinesis batches (>1000 records) to observe parallel_bulk performance gains

🤖 Generated with [Claude Code](https://claude.com/claude-code)